### PR TITLE
Add more info to assertion failure output

### DIFF
--- a/assertable/assertable.go
+++ b/assertable/assertable.go
@@ -48,6 +48,7 @@ func (a *Assertable) Assert(ex []Row) error {
 			fmt.Printf("%s\n", green("PASSED"))
 		} else {
 			fmt.Printf("%s\n", red("FAILED"))
+			fmt.Printf("    %s\n", e)
 			return e
 		}
 	}

--- a/assertable/matcher.go
+++ b/assertable/matcher.go
@@ -128,7 +128,16 @@ func (m *Matcher) Match(a *Assertable) (bool, error) {
 		if match {
 			return true, nil
 		}
-		return false, fmt.Errorf("expect %s in %s, but not", red(m.value), red(m.key))
+		var err error
+		switch len(val) {
+		case 0:
+			err = fmt.Errorf("%s is empty", red(m.key))
+		case 1:
+			err = fmt.Errorf("expect %s as %s, but acutal value is %s", red(m.value), red(m.key), red(val[0]))
+		default:
+			err = fmt.Errorf("expect %s in %s%q, but not", red(m.value), red(m.key), val)
+		}
+		return false, err
 	}
 	return false, fmt.Errorf("response does not contain %s", m.key)
 }


### PR DESCRIPTION
On assertion failed, we need some info to find failure cause.
`cotton` provides detail mode, but its output can be excessive in some cases.
This PR will add an essential info to assertion failure output.